### PR TITLE
Support homebrew's python3 that is not in /usr/bin/

### DIFF
--- a/download-list.py
+++ b/download-list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import urllib.request
 

--- a/get-lists.py
+++ b/get-lists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import urllib.request
 

--- a/redirect-response-extractor.py
+++ b/redirect-response-extractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Extract the contents of a Safe Browsing redirect response
 # and throw an exception in case of errors.

--- a/regex-lookup.py
+++ b/regex-lookup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # https://developers.google.com/safe-browsing/developers_guide_v2#RegexLookup
 


### PR DESCRIPTION
The safebrowsing-tools scripts assume python3 is in /usr/bin/. Unfortunately, OS X does not ship python3 and homebrew installs python3 in /usr/local/bin/. We can use /usr/bin/env to provide an extra indirection to support both Linux and OS X.
